### PR TITLE
fix typos and bad region; run go fmt

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -12,9 +12,9 @@ import (
 	// empty import as per https://godoc.org/github.com/lib/pq
 	_ "github.com/lib/pq"
 
-	"gopkg.in/yaml.v3"
 	"github.com/sirupsen/logrus"
 	"go.mozilla.org/sops/v3/logging"
+	"gopkg.in/yaml.v3"
 )
 
 var log *logrus.Logger

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -825,7 +825,7 @@ func main() {
 		if c.Bool("rotate") {
 			var addMasterKeys []keys.MasterKey
 			kmsEncryptionContext := kms.ParseKMSContext(c.String("encryption-context"))
-			for _, k := range kms.MasterKeysFromArnString(c.String("add-kms"), kmsEncryptionContext, c.String("aws-profile"), c.String("aws-endpoint")") {
+			for _, k := range kms.MasterKeysFromArnString(c.String("add-kms"), kmsEncryptionContext, c.String("aws-profile"), c.String("aws-endpoint")) {
 				addMasterKeys = append(addMasterKeys, k)
 			}
 			for _, k := range pgp.MasterKeysFromFingerprintString(c.String("add-pgp")) {
@@ -1089,7 +1089,7 @@ func keyGroups(c *cli.Context, file string) ([]sops.KeyGroup, error) {
 		return nil, common.NewExitError("Invalid KMS encryption context format", codes.ErrorInvalidKMSEncryptionContextFormat)
 	}
 	if c.String("kms") != "" {
-		for _, k := range kms.MasterKeysFromArnString(c.String("kms"), kmsEncryptionContext, c.String("aws-profile") c.String("aws-endpoint")) {
+		for _, k := range kms.MasterKeysFromArnString(c.String("kms"), kmsEncryptionContext, c.String("aws-profile"), c.String("aws-endpoint")) {
 			kmsKeys = append(kmsKeys, k)
 		}
 	}

--- a/cmd/sops/subcommand/exec/exec_unix.go
+++ b/cmd/sops/subcommand/exec/exec_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package exec

--- a/config/config.go
+++ b/config/config.go
@@ -331,7 +331,7 @@ func parseCreationRuleForFile(conf *configFile, confPath, filePath string, kmsEn
 	}
 
 	// compare file path relative to path of config file
-	filePath = strings.TrimPrefix(filePath, configDir + string(filepath.Separator))
+	filePath = strings.TrimPrefix(filePath, configDir+string(filepath.Separator))
 
 	var rule *creationRule
 

--- a/keyservice/keyservice.go
+++ b/keyservice/keyservice.go
@@ -53,10 +53,10 @@ func KeyFromMasterKey(mk keys.MasterKey) Key {
 		return Key{
 			KeyType: &Key_KmsKey{
 				KmsKey: &KmsKey{
-					Arn:        mk.Arn,
-					Role:       mk.Role,
-					Context:    ctx,
-					AwsProfile: mk.AwsProfile,
+					Arn:         mk.Arn,
+					Role:        mk.Role,
+					Context:     ctx,
+					AwsProfile:  mk.AwsProfile,
 					AwsEndpoint: mk.AwsEndpoint,
 				},
 			},

--- a/keyservice/keyservice.pb.go
+++ b/keyservice/keyservice.pb.go
@@ -217,11 +217,11 @@ type KmsKey struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Arn        string            `protobuf:"bytes,1,opt,name=arn,proto3" json:"arn,omitempty"`
-	Role       string            `protobuf:"bytes,2,opt,name=role,proto3" json:"role,omitempty"`
-	Context    map[string]string `protobuf:"bytes,3,rep,name=context,proto3" json:"context,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	AwsProfile string            `protobuf:"bytes,4,opt,name=aws_profile,json=awsProfile,proto3" json:"aws_profile,omitempty"`
-	AwsEndpoint string           `protobuf:"bytes,5,opt,name=aws_endpoint" json:"aws_endpoint,omitempty"`
+	Arn         string            `protobuf:"bytes,1,opt,name=arn,proto3" json:"arn,omitempty"`
+	Role        string            `protobuf:"bytes,2,opt,name=role,proto3" json:"role,omitempty"`
+	Context     map[string]string `protobuf:"bytes,3,rep,name=context,proto3" json:"context,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	AwsProfile  string            `protobuf:"bytes,4,opt,name=aws_profile,json=awsProfile,proto3" json:"aws_profile,omitempty"`
+	AwsEndpoint string            `protobuf:"bytes,5,opt,name=aws_endpoint" json:"aws_endpoint,omitempty"`
 }
 
 func (x *KmsKey) Reset() {

--- a/keyservice/server.go
+++ b/keyservice/server.go
@@ -324,6 +324,6 @@ func kmsKeyToMasterKey(key *KmsKey) kms.MasterKey {
 		Role:              key.Role,
 		EncryptionContext: ctx,
 		AwsProfile:        key.AwsProfile,
-		AwsEndpoint:        key.AwsEndpoint,
+		AwsEndpoint:       key.AwsEndpoint,
 	}
 }

--- a/kms/keysource.go
+++ b/kms/keysource.go
@@ -124,7 +124,7 @@ func (key *MasterKey) ToString() string {
 }
 
 // NewMasterKey creates a new MasterKey from an ARN, role and context, setting the creation date to the current date
-func NewMasterKey(arn string, role string, context map[string]*string) *MasterKey {
+func NewMasterKey(arn string, role string, context map[string]*string, awsEndpoint string) *MasterKey {
 	return &MasterKey{
 		Arn:               arn,
 		Role:              role,
@@ -135,7 +135,7 @@ func NewMasterKey(arn string, role string, context map[string]*string) *MasterKe
 }
 
 // NewMasterKeyFromArn takes an ARN string and returns a new MasterKey for that ARN
-func NewMasterKeyFromArn(arn string, context map[string]*string, awsProfile string) *MasterKey {
+func NewMasterKeyFromArn(arn string, context map[string]*string, awsProfile string, awsEndpoint string) *MasterKey {
 	k := &MasterKey{}
 	arn = strings.Replace(arn, " ", "", -1)
 	roleIndex := strings.Index(arn, "+arn:aws:iam::")
@@ -153,13 +153,13 @@ func NewMasterKeyFromArn(arn string, context map[string]*string, awsProfile stri
 }
 
 // MasterKeysFromArnString takes a comma separated list of AWS KMS ARNs and returns a slice of new MasterKeys for those ARNs
-func MasterKeysFromArnString(arn string, context map[string]*string, awsProfile string) []*MasterKey {
+func MasterKeysFromArnString(arn string, context map[string]*string, awsProfile string, awsEndpoint string) []*MasterKey {
 	var keys []*MasterKey
 	if arn == "" {
 		return keys
 	}
 	for _, s := range strings.Split(arn, ",") {
-		keys = append(keys, NewMasterKeyFromArn(s, context, awsProfile ))
+		keys = append(keys, NewMasterKeyFromArn(s, context, awsProfile, awsEndpoint))
 	}
 	return keys
 }
@@ -211,7 +211,7 @@ func (key MasterKey) createSession() (*session.Session, error) {
 			if service == endpoints.KmsServiceID {
 				return endpoints.ResolvedEndpoint{
 					URL:           key.AwsEndpoint,
-					SigningRegion: "custom-signing-region",
+					SigningRegion: region,
 				}, nil
 			}
 			return endpoints.DefaultResolver().EndpointFor(service, region, optFns...)

--- a/kms/keysource_test.go
+++ b/kms/keysource_test.go
@@ -48,7 +48,7 @@ func TestKMS(t *testing.T) {
 
 func TestKMSKeySourceFromString(t *testing.T) {
 	s := "arn:aws:kms:us-east-1:656532927350:key/920aff2e-c5f1-4040-943a-047fa387b27e+arn:aws:iam::927034868273:role/sops-dev, arn:aws:kms:ap-southeast-1:656532927350:key/9006a8aa-0fa6-4c14-930e-a2dfb916de1d"
-	ks := MasterKeysFromArnString(s, nil, "foo" "")
+	ks := MasterKeysFromArnString(s, nil, "foo", "")
 	k1 := ks[0]
 	k2 := ks[1]
 	expectedArn1 := "arn:aws:kms:us-east-1:656532927350:key/920aff2e-c5f1-4040-943a-047fa387b27e"

--- a/stores/yaml/store.go
+++ b/stores/yaml/store.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"strings"
 
-	"gopkg.in/yaml.v3"
 	"go.mozilla.org/sops/v3"
 	"go.mozilla.org/sops/v3/stores"
+	"gopkg.in/yaml.v3"
 )
 
 // Store handles storage of YAML data
@@ -76,7 +76,7 @@ func (store Store) nodeToTreeValue(node *yaml.Node, commentsWereHandled bool) (i
 		node.Decode(&result)
 		return result, nil
 	case yaml.AliasNode:
-		return store.nodeToTreeValue(node.Alias, false);
+		return store.nodeToTreeValue(node.Alias, false)
 	}
 	return nil, nil
 }
@@ -100,7 +100,7 @@ func (store Store) appendYamlNodeToTreeBranch(node *yaml.Node, branch sops.TreeB
 	case yaml.MappingNode:
 		for i := 0; i < len(node.Content); i += 2 {
 			key := node.Content[i]
-			value := node.Content[i + 1]
+			value := node.Content[i+1]
 			branch = store.appendCommentToMap(key.HeadComment, branch)
 			branch = store.appendCommentToMap(key.LineComment, branch)
 			handleValueComments := value.Kind == yaml.ScalarNode || value.Kind == yaml.AliasNode
@@ -206,7 +206,7 @@ func (store *Store) appendSequence(in []interface{}, sequence *yaml.Node) {
 		if beginning {
 			comments = store.addCommentsHead(sequence, comments)
 		} else {
-			comments = store.addCommentsFoot(sequence.Content[len(sequence.Content) - 1], comments)
+			comments = store.addCommentsFoot(sequence.Content[len(sequence.Content)-1], comments)
 		}
 	}
 }
@@ -233,7 +233,7 @@ func (store *Store) appendTreeBranch(branch sops.TreeBranch, mapping *yaml.Node)
 		if beginning {
 			comments = store.addCommentsHead(mapping, comments)
 		} else {
-			comments = store.addCommentsFoot(mapping.Content[len(mapping.Content) - 1], comments)
+			comments = store.addCommentsFoot(mapping.Content[len(mapping.Content)-1], comments)
 		}
 	}
 }
@@ -317,7 +317,7 @@ func (store *Store) LoadPlainFile(in []byte) (sops.TreeBranches, error) {
 // EmitEncryptedFile returns the encrypted bytes of the yaml file corresponding to a
 // sops.Tree runtime object
 func (store *Store) EmitEncryptedFile(in sops.Tree) ([]byte, error) {
-    var b bytes.Buffer
+	var b bytes.Buffer
 	e := yaml.NewEncoder(io.Writer(&b))
 	e.SetIndent(4)
 	for _, branch := range in.Branches {
@@ -331,7 +331,7 @@ func (store *Store) EmitEncryptedFile(in sops.Tree) ([]byte, error) {
 		// Create copy of branch with metadata appended
 		branch = append(sops.TreeBranch(nil), branch...)
 		branch = append(branch, sops.TreeItem{
-			Key: "sops",
+			Key:   "sops",
 			Value: stores.MetadataFromInternal(in.Metadata),
 		})
 		// Marshal branch to global mapping node
@@ -349,7 +349,7 @@ func (store *Store) EmitEncryptedFile(in sops.Tree) ([]byte, error) {
 // EmitPlainFile returns the plaintext bytes of the yaml file corresponding to a
 // sops.TreeBranches runtime object
 func (store *Store) EmitPlainFile(branches sops.TreeBranches) ([]byte, error) {
-    var b bytes.Buffer
+	var b bytes.Buffer
 	e := yaml.NewEncoder(io.Writer(&b))
 	e.SetIndent(4)
 	for _, branch := range branches {

--- a/stores/yaml/store_test.go
+++ b/stores/yaml/store_test.go
@@ -101,7 +101,7 @@ var COMMENT_6 = []byte(`a:
 var COMMENT_6_BRANCHES = sops.TreeBranches{
 	sops.TreeBranch{
 		sops.TreeItem{
-			Key:   "a",
+			Key: "a",
 			Value: []interface{}{
 				"a",
 				sops.Comment{" I no longer get duplicated"},


### PR DESCRIPTION
- found some typos that needed to be fixed
- fixed a problem with the custom region being set as `custom-signing-region` (not sure why the original PR author did that, but it doesn't work!)
- ran `go fmt ./...`